### PR TITLE
[app_settins] Màj url taxhub

### DIFF
--- a/app_settings.json
+++ b/app_settings.json
@@ -2,7 +2,7 @@
   "area_observation_duration": 365,
   "sync": {
     "geonature_url": "https://clicnat.fr/geonature",
-    "taxhub_url": "https://clicnat.fr/taxhub",
+    "taxhub_url": "https://clicnat.fr/geonature/api/taxhub",
     "gn_application_id": 1,
     "observers_list_id": 1,
     "taxa_list_id": 100,


### PR DESCRIPTION
Une PR toute simple qui met à jour l'URL de TaxHub dans la configuration de l'appli, suite au passage à Taxhub v2.

Le nouveau fichier est sur le serveur : testé chez moi, ça marche.